### PR TITLE
Handle item keys case-insensitively

### DIFF
--- a/basic.C
+++ b/basic.C
@@ -458,3 +458,13 @@ GLOBALFUN UINT32 Tokenize(const string &line, string *array, UINT32 n) {
   return count;
 }
 // ========================================================================
+
+GLOBALFUN BOOL CaseCompare(const string &s1, const string &s2) {
+  if (s2.size() != s1.size())
+    return false;
+  for (unsigned int i = 0; i < s1.size(); ++i)
+    if (tolower(s1[i]) != tolower(s2[i]))
+      return false;
+  return true;
+}
+// ========================================================================

--- a/basic.H
+++ b/basic.H
@@ -115,6 +115,8 @@ extern std::string Reformat(const std::string &s, const std::string &prefix,
 
 extern UINT32 Tokenize(const std::string &line, std::string *array, UINT32 n);
 
+extern BOOL CaseCompare(const std::string &s1, const std::string &s2);
+
 // ========================================================================
 extern const std::string Line1;
 extern const std::string Line2;

--- a/golden.out
+++ b/golden.out
@@ -8,6 +8,9 @@ W: file does not contain ape tag
 Found APE tag at offset 193
 Items:
 "Title" "--title--"
+Found APE tag at offset 193
+Items:
+"title" "--title--"
 ============================================================
 test 3
 W: file does not contain ape tag
@@ -71,4 +74,8 @@ Found APE tag at offset 193
 Items:
 "Test" "File"
 "Test.sh" <Binary>
+Found APE tag at offset 193
+Items:
+"test" "File"
+"test.sh" <Binary>
 done

--- a/test.sh
+++ b/test.sh
@@ -33,6 +33,8 @@ ${APETAG} -i ${MP3_CLONE} -m read
 newtest
 ${APETAG} -i ${MP3_CLONE} -m update -p  "Title=--title--"
 ${APETAG} -i ${MP3_CLONE} -m read
+${APETAG} -i ${MP3_CLONE} -m update -p  "title=--title--"
+${APETAG} -i ${MP3_CLONE} -m read
 
 
 newtest
@@ -54,6 +56,8 @@ ${APETAG} -i ${MP3_CLONE} -m read
 newtest
 ${APETAG} -i ${MP3_CLONE} -m update -f  "Test.sh"=${BIN1}
 ${APETAG} -i ${MP3_CLONE} -m read
+${APETAG} -i ${MP3_CLONE} -m update -f  "test.sh"=${BIN1}
+${APETAG} -i ${MP3_CLONE} -m read
 
 
 newtest
@@ -74,6 +78,8 @@ ${APETAG} -i ${MP3_CLONE} -m read
 
 newtest
 ${APETAG} -i ${MP3_CLONE} -m update -f "Test.sh"=${BIN1} -p "Test"="File"
+${APETAG} -i ${MP3_CLONE} -m read
+${APETAG} -i ${MP3_CLONE} -m update -f "test.sh"=${BIN1} -p "test"="File"
 ${APETAG} -i ${MP3_CLONE} -m read
 
 echo "done"


### PR DESCRIPTION
Tag item keys should be compared case-insensitively so as to avoid duplicate tag keys with stale values. The APEv2 spec says that item keys differing only by case are not allowed.