### PR TITLE
Dump and source an external tag

### DIFF
--- a/basic.C
+++ b/basic.C
@@ -458,3 +458,13 @@ GLOBALFUN UINT32 Tokenize(const string &line, string *array, UINT32 n) {
   return count;
 }
 // ========================================================================
+
+GLOBALFUN BOOL CaseCompare(const string &s1, const string &s2) {
+  if (s2.size() != s1.size())
+    return false;
+  for (unsigned int i = 0; i < s1.size(); ++i)
+    if (tolower(s1[i]) != tolower(s2[i]))
+      return false;
+  return true;
+}
+// ========================================================================

--- a/basic.H
+++ b/basic.H
@@ -115,6 +115,8 @@ extern std::string Reformat(const std::string &s, const std::string &prefix,
 
 extern UINT32 Tokenize(const std::string &line, std::string *array, UINT32 n);
 
+extern BOOL CaseCompare(const std::string &s1, const std::string &s2);
+
 // ========================================================================
 extern const std::string Line1;
 extern const std::string Line2;

--- a/golden.out
+++ b/golden.out
@@ -7,21 +7,21 @@ test 2
 W: file does not contain ape tag
 Found APE tag at offset 193
 Items:
-"Title" "--title--"
+TXT "Title" "--title--"
 Found APE tag at offset 193
 Items:
-"title" "--title--"
+TXT "title" "--title--"
 ============================================================
 test 3
 W: file does not contain ape tag
 Found APE tag at offset 193
 Items:
-"Year" "--year2--"
-"Title" "--title2--"
+TXT "Year" "--year2--"
+TXT "Title" "--title2--"
 W: truncating file from 303 to 281
 Found APE tag at offset 193
 Items:
-"Title" "--title3--"
+TXT "Title" "--title3--"
 W: truncating file from 281 to 193
 W: file does not contain ape tag
 No valid APE tag found
@@ -30,32 +30,32 @@ test 4
 W: file does not contain ape tag
 Found APE tag at offset 193
 Items:
-"Year" "--year2--"
-"Title" "--title2--"
+TXT "Year" "--year2--"
+TXT "Title" "--title2--"
 W: truncating file from 303 to 281
 Found APE tag at offset 193
 Items:
-"Title" "--title3--"
+TXT "Title" "--title3--"
 ============================================================
 test 5
 W: file does not contain ape tag
 Found APE tag at offset 193
 Items:
-"Test.sh" <Binary>
+BIN "Test.sh"
 Found APE tag at offset 193
 Items:
-"test.sh" <Binary>
+BIN "test.sh"
 ============================================================
 test 6
 W: file does not contain ape tag
 Found APE tag at offset 193
 Items:
-"NotTest" <Binary>
-"Test.sh" <Binary>
+BIN "NotTest"
+BIN "Test.sh"
 W: truncating file from 70585 to 1374
 Found APE tag at offset 193
 Items:
-"Test.sh" <Binary>
+BIN "Test.sh"
 W: truncating file from 1374 to 193
 W: file does not contain ape tag
 No valid APE tag found
@@ -64,32 +64,32 @@ test 7
 W: file does not contain ape tag
 Found APE tag at offset 193
 Items:
-"NotTest" <Binary>
-"Test.sh" <Binary>
+BIN "NotTest"
+BIN "Test.sh"
 W: truncating file from 70585 to 1374
 Found APE tag at offset 193
 Items:
-"Test.sh" <Binary>
+BIN "Test.sh"
 ============================================================
 test 8
 W: file does not contain ape tag
 Found APE tag at offset 193
 Items:
-"TestPage" "http://bo.gus/addr"
+ERS "TestPage" "http://bo.gus/addr"
 Found APE tag at offset 193
 Items:
-"testpage" "http://bo.gus/addr"
+ERS "testpage" "http://bo.gus/addr"
 ============================================================
 test 9
 W: file does not contain ape tag
 Found APE tag at offset 193
 Items:
-"ExternalCover" "/dev/zero"
-"TestPage" "http://bo.gus/website/page.html"
+ERS "ExternalCover" "/dev/zero"
+ERS "TestPage" "http://bo.gus/website/page.html"
 W: truncating file from 336 to 306
 Found APE tag at offset 193
 Items:
-"TestPage" "http://bo.gus/addr/testpage.html"
+ERS "TestPage" "http://bo.gus/addr/testpage.html"
 W: truncating file from 306 to 193
 W: file does not contain ape tag
 No valid APE tag found
@@ -98,23 +98,23 @@ test 10
 W: file does not contain ape tag
 Found APE tag at offset 193
 Items:
-"ExternalCover" "/dev/zero"
-"TestPage" "http://bo.gus/website/page.html"
+ERS "ExternalCover" "/dev/zero"
+ERS "TestPage" "http://bo.gus/website/page.html"
 W: truncating file from 336 to 306
 Found APE tag at offset 193
 Items:
-"TestPage" "http://bo.gus/addr/testpage.html"
+ERS "TestPage" "http://bo.gus/addr/testpage.html"
 ============================================================
 test 11
 W: file does not contain ape tag
 Found APE tag at offset 193
 Items:
-"Test" "File"
-"ExternalCover" "/dev/zero"
-"Test.sh" <Binary>
+TXT "Test" "File"
+ERS "ExternalCover" "/dev/zero"
+BIN "Test.sh"
 Found APE tag at offset 193
 Items:
-"test" "File"
-"externalcover" "/dev/zero"
-"test.sh" <Binary>
+TXT "test" "File"
+ERS "externalcover" "/dev/zero"
+BIN "test.sh"
 done

--- a/golden.out
+++ b/golden.out
@@ -229,4 +229,16 @@ Items:
 TXT "Title" "--title2--" RW
 ERS "testpage" "http://bo.gus/website/page.html" RW
 BIN "test.sh" RW
+============================================================
+test 17
+W: file does not contain ape tag
+W: truncating file from 6577 to 193
+W: file does not contain ape tag
+No valid APE tag found
+W: file does not contain ape tag
+Found APE tag at offset 193
+Items:
+TXT "Title" "--title2--" RW
+ERS "testpage" "http://bo.gus/website/page.html" RW
+BIN "test.sh" RW
 done

--- a/golden.out
+++ b/golden.out
@@ -8,6 +8,9 @@ W: file does not contain ape tag
 Found APE tag at offset 193
 Items:
 "Title" "--title--"
+Found APE tag at offset 193
+Items:
+"title" "--title--"
 ============================================================
 test 3
 W: file does not contain ape tag
@@ -71,4 +74,8 @@ Found APE tag at offset 193
 Items:
 "Test" "File"
 "Test.sh" <Binary>
+Found APE tag at offset 193
+Items:
+"test" "File"
+"test.sh" <Binary>
 done

--- a/golden.out
+++ b/golden.out
@@ -42,6 +42,9 @@ W: file does not contain ape tag
 Found APE tag at offset 193
 Items:
 "Test.sh" <Binary>
+Found APE tag at offset 193
+Items:
+"test.sh" <Binary>
 ============================================================
 test 6
 W: file does not contain ape tag
@@ -72,10 +75,46 @@ test 8
 W: file does not contain ape tag
 Found APE tag at offset 193
 Items:
+"TestPage" "http://bo.gus/addr"
+Found APE tag at offset 193
+Items:
+"testpage" "http://bo.gus/addr"
+============================================================
+test 9
+W: file does not contain ape tag
+Found APE tag at offset 193
+Items:
+"ExternalCover" "/dev/zero"
+"TestPage" "http://bo.gus/website/page.html"
+W: truncating file from 336 to 306
+Found APE tag at offset 193
+Items:
+"TestPage" "http://bo.gus/addr/testpage.html"
+W: truncating file from 306 to 193
+W: file does not contain ape tag
+No valid APE tag found
+============================================================
+test 10
+W: file does not contain ape tag
+Found APE tag at offset 193
+Items:
+"ExternalCover" "/dev/zero"
+"TestPage" "http://bo.gus/website/page.html"
+W: truncating file from 336 to 306
+Found APE tag at offset 193
+Items:
+"TestPage" "http://bo.gus/addr/testpage.html"
+============================================================
+test 11
+W: file does not contain ape tag
+Found APE tag at offset 193
+Items:
 "Test" "File"
+"ExternalCover" "/dev/zero"
 "Test.sh" <Binary>
 Found APE tag at offset 193
 Items:
 "test" "File"
+"externalcover" "/dev/zero"
 "test.sh" <Binary>
 done

--- a/golden.out
+++ b/golden.out
@@ -7,114 +7,212 @@ test 2
 W: file does not contain ape tag
 Found APE tag at offset 193
 Items:
-TXT "Title" "--title--"
+TXT "Title" "--title--" RW
 Found APE tag at offset 193
 Items:
-TXT "title" "--title--"
+TXT "title" "--title--" RW
+W: item "titl" not found
+W: item "titl" not found
+Found APE tag at offset 193
+Items:
+TXT "title" "--title--" RW
 ============================================================
 test 3
 W: file does not contain ape tag
 Found APE tag at offset 193
 Items:
-TXT "Year" "--year2--"
-TXT "Title" "--title2--"
+TXT "Year" "--year2--" RW
+TXT "Title" "--title2--" RW
 W: truncating file from 303 to 281
 Found APE tag at offset 193
 Items:
-TXT "Title" "--title3--"
+TXT "Title" "--title3--" RW
 W: truncating file from 281 to 193
 W: file does not contain ape tag
 No valid APE tag found
 ============================================================
 test 4
 W: file does not contain ape tag
+W: read only item with key Title was not modified
 Found APE tag at offset 193
 Items:
-TXT "Year" "--year2--"
-TXT "Title" "--title2--"
+TXT "Year" "--year2--" RW
+TXT "Title" "--title2--" RO
+W: read only item with key Title was not erased
 W: truncating file from 303 to 281
 Found APE tag at offset 193
 Items:
-TXT "Title" "--title3--"
+TXT "Title" "--title2--" RO
+Found APE tag at offset 193
+Items:
+TXT "Title" "--title2--" RW
+W: truncating file from 281 to 257
+Found APE tag at offset 193
+Items:
 ============================================================
 test 5
 W: file does not contain ape tag
 Found APE tag at offset 193
 Items:
-BIN "Test.sh"
+TXT "Year" "--year2--" RW
+TXT "Title" "--title2--" RW
+W: truncating file from 303 to 281
 Found APE tag at offset 193
 Items:
-BIN "test.sh"
+TXT "Title" "--title3--" RW
 ============================================================
 test 6
 W: file does not contain ape tag
 Found APE tag at offset 193
 Items:
-BIN "NotTest"
-BIN "Test.sh"
-W: truncating file from 70585 to 1374
+BIN "Test.sh" RW
 Found APE tag at offset 193
 Items:
-BIN "Test.sh"
-W: truncating file from 1374 to 193
-W: file does not contain ape tag
-No valid APE tag found
+BIN "test.sh" RW
+W: item "test" not found
+W: item "test" not found
+Found APE tag at offset 193
+Items:
+BIN "test.sh" RW
 ============================================================
 test 7
 W: file does not contain ape tag
 Found APE tag at offset 193
 Items:
-BIN "NotTest"
-BIN "Test.sh"
+BIN "NotTest" RW
+BIN "Test.sh" RW
 W: truncating file from 70585 to 1374
 Found APE tag at offset 193
 Items:
-BIN "Test.sh"
+BIN "Test.sh" RW
+W: truncating file from 1374 to 193
+W: file does not contain ape tag
+No valid APE tag found
 ============================================================
 test 8
 W: file does not contain ape tag
+W: read only item with key Test.sh was not modified
 Found APE tag at offset 193
 Items:
-ERS "TestPage" "http://bo.gus/addr"
+BIN "NotTest" RW
+BIN "Test.sh" RO
+W: read only item with key Test.sh was not erased
+W: truncating file from 70585 to 35421
 Found APE tag at offset 193
 Items:
-ERS "testpage" "http://bo.gus/addr"
+BIN "Test.sh" RO
+Found APE tag at offset 193
+Items:
+BIN "Test.sh" RW
+W: truncating file from 35421 to 257
+Found APE tag at offset 193
+Items:
 ============================================================
 test 9
 W: file does not contain ape tag
 Found APE tag at offset 193
 Items:
-ERS "ExternalCover" "/dev/zero"
-ERS "TestPage" "http://bo.gus/website/page.html"
-W: truncating file from 336 to 306
+BIN "NotTest" RW
+BIN "Test.sh" RW
+W: truncating file from 70585 to 1374
 Found APE tag at offset 193
 Items:
-ERS "TestPage" "http://bo.gus/addr/testpage.html"
-W: truncating file from 306 to 193
-W: file does not contain ape tag
-No valid APE tag found
+BIN "Test.sh" RW
 ============================================================
 test 10
 W: file does not contain ape tag
 Found APE tag at offset 193
 Items:
-ERS "ExternalCover" "/dev/zero"
-ERS "TestPage" "http://bo.gus/website/page.html"
-W: truncating file from 336 to 306
+ERS "TestPage" "http://bo.gus/addr" RW
 Found APE tag at offset 193
 Items:
-ERS "TestPage" "http://bo.gus/addr/testpage.html"
+ERS "testpage" "http://bo.gus/addr" RW
+W: item "page" not found
+W: item "page" not found
+Found APE tag at offset 193
+Items:
+ERS "testpage" "http://bo.gus/addr" RW
 ============================================================
 test 11
 W: file does not contain ape tag
 Found APE tag at offset 193
 Items:
-TXT "Test" "File"
-ERS "ExternalCover" "/dev/zero"
-BIN "Test.sh"
+ERS "ExternalCover" "/dev/zero" RW
+ERS "TestPage" "http://bo.gus/website/page.html" RW
+W: truncating file from 336 to 306
 Found APE tag at offset 193
 Items:
-TXT "test" "File"
-ERS "externalcover" "/dev/zero"
-BIN "test.sh"
+ERS "TestPage" "http://bo.gus/addr/testpage.html" RW
+W: truncating file from 306 to 193
+W: file does not contain ape tag
+No valid APE tag found
+============================================================
+test 12
+W: file does not contain ape tag
+W: read only item with key TestPage was not modified
+Found APE tag at offset 193
+Items:
+ERS "ExternalCover" "/dev/zero" RW
+ERS "TestPage" "http://bo.gus/website/page.html" RO
+W: read only item with key TestPage was not erased
+W: truncating file from 336 to 305
+Found APE tag at offset 193
+Items:
+ERS "TestPage" "http://bo.gus/website/page.html" RO
+Found APE tag at offset 193
+Items:
+ERS "TestPage" "http://bo.gus/website/page.html" RW
+W: truncating file from 305 to 257
+Found APE tag at offset 193
+Items:
+============================================================
+test 13
+W: file does not contain ape tag
+Found APE tag at offset 193
+Items:
+ERS "ExternalCover" "/dev/zero" RW
+ERS "TestPage" "http://bo.gus/website/page.html" RW
+W: truncating file from 336 to 306
+Found APE tag at offset 193
+Items:
+ERS "TestPage" "http://bo.gus/addr/testpage.html" RW
+============================================================
+test 14
+W: file does not contain ape tag
+Found APE tag at offset 193
+Items:
+TXT "Test" "File" RW
+ERS "ExternalCover" "/dev/zero" RW
+BIN "Test.sh" RW
+Found APE tag at offset 193
+Items:
+TXT "test" "File" RW
+ERS "externalcover" "/dev/zero" RW
+BIN "test.sh" RW
+============================================================
+test 15
+W: file does not contain ape tag
+Found APE tag at offset 193
+Items:
+TXT "test" "file" RO
+ERS "externalcover" "/dev/zero" RO
+BIN "test.sh" RO
+W: read only item with key test was not modified
+W: read only item with key externalcover was not modified
+W: read only item with key test.sh was not modified
+Found APE tag at offset 193
+Items:
+TXT "test" "file" RO
+ERS "externalcover" "/dev/zero" RO
+BIN "test.sh" RO
+Found APE tag at offset 193
+Items:
+TXT "test" "file" RW
+ERS "externalcover" "/dev/zero" RW
+BIN "test.sh" RW
+Found APE tag at offset 193
+Items:
+TXT "test" "FILE2" RW
+ERS "externalcover" "/DEV/ZERO" RW
+BIN "test.sh" RW
 done

--- a/golden.out
+++ b/golden.out
@@ -215,4 +215,18 @@ Items:
 TXT "test" "FILE2" RW
 ERS "externalcover" "/DEV/ZERO" RW
 BIN "test.sh" RW
+============================================================
+test 16
+W: file does not contain ape tag
+Found APE tag at offset 193
+TAG IS SET READ ONLY
+Items:
+TXT "Title" "--title2--" RW
+ERS "testpage" "http://bo.gus/website/page.html" RW
+BIN "test.sh" RW
+Found APE tag at offset 193
+Items:
+TXT "Title" "--title2--" RW
+ERS "testpage" "http://bo.gus/website/page.html" RW
+BIN "test.sh" RW
 done

--- a/main.C
+++ b/main.C
@@ -98,6 +98,9 @@ LOCALFUN string ExtractVersion() {
 #define APE_FLAG_HAVE_HEADER (1 << 31)
 #define APE_FLAG_IS_HEADER (1 << 29)
 
+#define APE_FLAG_READWRITE (0 << 0)
+#define APE_FLAG_READONLY (1 << 0)
+
 #define APE_TAG_ITEM_FLAG_TEXT (0 << 0)
 #define APE_TAG_ITEM_FLAG_BINARY (1 << 1)
 #define APE_TAG_ITEM_FLAG_EXTERNAL_RESOURCE (1 << 2)

--- a/main.C
+++ b/main.C
@@ -488,6 +488,11 @@ SWITCH SwitchPair(
     "specify ape tag and value, arguments must have form tag=val, this option "
     "can be used multiple times");
 
+SWITCH SwitchResourcePair(
+    "r", "general", SWITCH_TYPE_STRING, SWITCH_MODE_ACCUMULATE, "$none$",
+    "specify ape tag and value indicating external resource, arguments must "
+    "have form tag=val, this option can be used multiple times");
+
 SWITCH SwitchFilePair(
     "f", "general", SWITCH_TYPE_STRING, SWITCH_MODE_ACCUMULATE, "$none$",
     "specify ape tag and pathname for embedding or extracting data, arguments "
@@ -503,7 +508,7 @@ int Usage() {
   cout << R"STR(
 Web: http://www.muth.org/Robert/Apetag
 
-Usage: apetag -i input-file -m mode  {[-p|-f] tag=value}*
+Usage: apetag -i input-file -m mode  {[-p|-f|-r] tag=value}*
 
 change or create APE tag for file input-file
 
@@ -516,15 +521,15 @@ Mode read (default):
 
 Mode update:
     change selected key,value pairs
-    the pairs are specified with the -p or -f options
-        e.g.: -p Artist=Nosferaru -p Album=Bite
-    remove item Artist, change item Album to Cool
-    tags not listed with the -p or -f option will remain unchanged
+    the pairs are specified with the -p, -f, or -r options
+        e.g.: -p Artist=Nosferaru -p Album=Bite -r Homepage=http://nos.fer/bite
+    update items Artist, Album and Homepage
+    tags not listed with the -p, -f, or -r option will remain unchanged
     tags with empty values are removed
 
 Mode overwrite:
-    Overwrite all the tags with items specified by the -p or -f options
-    tags not listed with the -p or -f option will be removed
+    Overwrite all the tags with items specified by the -p, -f, or -r options
+    tags not listed with the -p, -f, or -r option will be removed
     this mode is also used to create ape tags initially
 
 Mode erase:
@@ -626,6 +631,21 @@ void HandleModeUpdate(TAG *tag) {
     Debug("adding (" + key + "," + val + ")\n");
 
     tag->UpdateItem(new ITEM(key, val, APE_TAG_ITEM_FLAG_TEXT));
+  }
+
+  const UINT32 num_resource_items = SwitchResourcePair.ValueNumber();
+
+  // we skip the first entry
+  for (UINT32 i = 1; i < num_resource_items; i++) {
+    const pair<string, string> pair =
+        ParsedPair(SwitchResourcePair.ValueString(i));
+
+    const string &key = pair.first;
+    const string &val = pair.second;
+
+    Debug("adding (" + key + "," + val + ")\n");
+
+    tag->UpdateItem(new ITEM(key, val, APE_TAG_ITEM_FLAG_EXTERNAL_RESOURCE));
   }
 
   const UINT32 num_file_items = SwitchFilePair.ValueNumber();

--- a/main.C
+++ b/main.C
@@ -483,15 +483,15 @@ SWITCH SwitchInputFile("i", " general", SWITCH_TYPE_STRING,
 SWITCH SwitchDebug("debug", "general", SWITCH_TYPE_BOOL, SWITCH_MODE_OVERWRITE,
                    "0", "enable debug mode");
 
-SWITCH
-SwitchPair("p", "general", SWITCH_TYPE_STRING, SWITCH_MODE_ACCUMULATE, "$none$",
-           "specify ape tag and value, arguments must have form tag=val, "
-           "this option can be used multiple times");
+SWITCH SwitchPair(
+    "p", "general", SWITCH_TYPE_STRING, SWITCH_MODE_ACCUMULATE, "$none$",
+    "specify ape tag and value, arguments must have form tag=val, this option "
+    "can be used multiple times");
 
 SWITCH SwitchFilePair(
     "f", "general", SWITCH_TYPE_STRING, SWITCH_MODE_ACCUMULATE, "$none$",
-    "specify ape tag and file pathname, arguments must have form "
-    "tag=pathname, this option can be used multiple times");
+    "specify ape tag and pathname for embedding or extracting data, arguments "
+    "must have form tag=pathname, this option can be used multiple times");
 
 SWITCH SwitchMode("m", "general", SWITCH_TYPE_STRING, SWITCH_MODE_OVERWRITE,
                   "read", "specify mode (read, update, overwrite, or erase)");

--- a/main.C
+++ b/main.C
@@ -510,14 +510,14 @@ change or create APE tag for file input-file
 apetag operates in one of three modes:
 Mode read (default):
     read and dump APE tag if present
-    dump an item to a file with the -f option
+    extract an item to a file with the -f option
         e.g.: -f "Cover Art (front)"=cover.jpg
-    dump item "Cover Art (front)" to file cover.jpg
+    extract item "Cover Art (front)" to file cover.jpg
 
 Mode update:
     change selected key,value pairs
     the pairs are specified with the -p or -f options
-        e.g.: -p Artist=Nosferaru -p Album=Bite 
+        e.g.: -p Artist=Nosferaru -p Album=Bite
     remove item Artist, change item Album to Cool
     tags not listed with the -p or -f option will remain unchanged
     tags with empty values are removed

--- a/main.C
+++ b/main.C
@@ -537,6 +537,26 @@ Switch summary:
   return -1;
 }
 
+const pair<string, string> ParsedPair (const string &pair) {
+  const UINT32 len = pair.length();
+
+  UINT32 pos_equal_sign;
+  for (pos_equal_sign = 0; pos_equal_sign < len; pos_equal_sign++) {
+    if (pair[pos_equal_sign] == '=')
+      break;
+  }
+
+  if (pos_equal_sign >= len) {
+    Error("pair : " + pair + " does not contain a \'=\'\n");
+  }
+
+  const string key = pair.substr(0, pos_equal_sign);
+  pos_equal_sign++;
+  const string val = pair.substr(pos_equal_sign, len - pos_equal_sign);
+
+  return make_pair(key, val);
+}
+
 void HandleModeRead(TAG *tag) {
   map<string, string> items;
 
@@ -563,23 +583,11 @@ void HandleModeRead(TAG *tag) {
 
   // we skip the first entry
   for (UINT32 i = 1; i < num_file_items; i++) {
-    const string &pair = SwitchFilePair.ValueString(i);
+    const pair<string, string> pair =
+        ParsedPair(SwitchFilePair.ValueString(i));
 
-    const UINT32 len = pair.length();
-
-    UINT32 pos_equal_sign;
-    for (pos_equal_sign = 0; pos_equal_sign < len; pos_equal_sign++) {
-      if (pair[pos_equal_sign] == '=')
-        break;
-    }
-
-    if (pos_equal_sign >= len) {
-      Error("pair : " + pair + " does not contain a \'=\'\n");
-    }
-
-    string key = pair.substr(0, pos_equal_sign);
-    pos_equal_sign++;
-    string val = pair.substr(pos_equal_sign, len - pos_equal_sign);
+    const string &key = pair.first;
+    const string &val = pair.second;
 
     if (items.count(key)) {
       const string &value = items[key];
@@ -606,28 +614,14 @@ void HandleModeRead(TAG *tag) {
 }
 
 void HandleModeUpdate(TAG *tag) {
-
   const UINT32 num_items = SwitchPair.ValueNumber();
 
   // we skip the first entry
   for (UINT32 i = 1; i < num_items; i++) {
-    const string &pair = SwitchPair.ValueString(i);
+    const pair<string, string> pair = ParsedPair(SwitchPair.ValueString(i));
 
-    const UINT32 len = pair.length();
-
-    UINT32 pos_equal_sign;
-    for (pos_equal_sign = 0; pos_equal_sign < len; pos_equal_sign++) {
-      if (pair[pos_equal_sign] == '=')
-        break;
-    }
-
-    if (pos_equal_sign >= len) {
-      Error("pair : " + pair + " does not contain a \'=\'\n");
-    }
-
-    string key = pair.substr(0, pos_equal_sign);
-    pos_equal_sign++;
-    string val = pair.substr(pos_equal_sign, len - pos_equal_sign);
+    const string &key = pair.first;
+    const string &val = pair.second;
 
     Debug("adding (" + key + "," + val + ")\n");
 
@@ -638,23 +632,10 @@ void HandleModeUpdate(TAG *tag) {
 
   // we skip the first entry
   for (UINT32 i = 1; i < num_file_items; i++) {
-    const string &pair = SwitchFilePair.ValueString(i);
+    pair<string, string> pair = ParsedPair(SwitchFilePair.ValueString(i));
 
-    const UINT32 len = pair.length();
-
-    UINT32 pos_equal_sign;
-    for (pos_equal_sign = 0; pos_equal_sign < len; pos_equal_sign++) {
-      if (pair[pos_equal_sign] == '=')
-        break;
-    }
-
-    if (pos_equal_sign >= len) {
-      Error("pair : " + pair + " does not contain a \'=\'\n");
-    }
-
-    string key = pair.substr(0, pos_equal_sign);
-    pos_equal_sign++;
-    string val = pair.substr(pos_equal_sign, len - pos_equal_sign);
+    const string &key = pair.first;
+    string val = pair.second;
 
     if (val.length()) {
       fstream file;

--- a/main.C
+++ b/main.C
@@ -184,11 +184,12 @@ private:
   UINT32 _tag_offset;
   UINT32 _num_items;
   ITEM_SET _items;
+  UINT32 _flags;
 
 public:
-  TAG(UINT32 file_length, UINT32 tag_offset, UINT32 num_items)
+  TAG(UINT32 file_length, UINT32 tag_offset, UINT32 num_items, UINT32 flags)
       : _file_length(file_length), _tag_offset(tag_offset),
-        _num_items(num_items) {
+        _num_items(num_items), _flags(flags) {
     Debug("num items: " + hexstr(_num_items) + "\n");
   }
 
@@ -307,13 +308,23 @@ public:
     }
     return count;
   }
+
+  VOID SetFlags(const UINT32 &flags) {
+     Debug("setting tag with flags " + hexstr(flags) + "\n");
+    _flags = flags;
+  }
+
+  UINT32 Flags() const {
+    return _flags;
+  }
 };
 
 LOCALFUN VOID WriteApeHeaderFooter(fstream &input, const TAG *tag,
                                    UINT32 flags) {
   char buf[4];
 
-  Info("writing header/footer at " + decstr(int(input.tellp())) + "\n");
+  Info("writing header/footer at " + decstr(int(input.tellp())) + " flags: " +
+       hexstr(flags) + "\n");
 
   if (sizeof(APE_HEADER_FOOTER) != 32)
     Error("bad size");
@@ -387,9 +398,9 @@ LOCALFUN VOID WriteApeTag(fstream &input, const TAG *tag,
             " target pos " + decstr(tag_offset) + "\n");
   }
 
-  WriteApeHeaderFooter(input, tag, APE_FLAG_IS_HEADER | APE_FLAG_HAVE_HEADER);
+  WriteApeHeaderFooter(input, tag, tag->Flags() | APE_FLAG_IS_HEADER | APE_FLAG_HAVE_HEADER);
   WriteApeItems(input, tag);
-  WriteApeHeaderFooter(input, tag, APE_FLAG_HAVE_HEADER);
+  WriteApeHeaderFooter(input, tag, tag->Flags() | APE_FLAG_HAVE_HEADER);
 
   UINT32 pos = input.tellp();
 
@@ -413,7 +424,7 @@ LOCALFUN TAG *ReadAndProcessApeHeader(fstream &input) {
 
   if (file_length < sizeof(APE_HEADER_FOOTER)) {
     Info("file too short to contain ape tag\n");
-    return new TAG(file_length, 0, 0);
+    return new TAG(file_length, 0, 0, 0);
   }
 
   // read footer
@@ -426,7 +437,7 @@ LOCALFUN TAG *ReadAndProcessApeHeader(fstream &input) {
 
   if (magic != APE_MAGIC) {
     Warning("file does not contain ape tag\n");
-    return new TAG(file_length, 0, 0);
+    return new TAG(file_length, 0, 0, 0);
   }
 
   const UINT32 version = ReadLittleEndianUint32(ape._version);
@@ -444,11 +455,13 @@ LOCALFUN TAG *ReadAndProcessApeHeader(fstream &input) {
 
   if (file_length < length) {
     Warning("tag bigger than file\n");
-    return new TAG(file_length, 0, 0);
+    return new TAG(file_length, 0, 0, 0);
   }
 
   // read header if any
   BOOL have_header = 0;
+
+  UINT32 tagflags = 0;
 
   if (file_length >= length + sizeof(APE_HEADER_FOOTER)) {
     input.seekg(-(INT32)(length + sizeof(APE_HEADER_FOOTER)), ios::end);
@@ -465,6 +478,10 @@ LOCALFUN TAG *ReadAndProcessApeHeader(fstream &input) {
       const UINT32 items2 = ReadLittleEndianUint32(ape2._items);
       const UINT32 flags2 = ReadLittleEndianUint32(ape2._flags);
 
+      tagflags = flags2;
+      tagflags &= ~APE_FLAG_HAVE_HEADER;
+      tagflags &= ~APE_FLAG_IS_HEADER;
+
       if (version != version2 || length != length2 || items != items2) {
         Warning("header footer data mismatch\n");
       }
@@ -477,7 +494,7 @@ LOCALFUN TAG *ReadAndProcessApeHeader(fstream &input) {
 
   TAG *tag = new TAG(
       file_length,
-      file_length - length - have_header * sizeof(APE_HEADER_FOOTER), items);
+      file_length - length - have_header * sizeof(APE_HEADER_FOOTER), items, tagflags);
 
   // read and process tag data
 
@@ -541,7 +558,8 @@ SWITCH SwitchFilePair(
     "must have form tag=pathname, this option can be used multiple times");
 
 SWITCH SwitchMode("m", "general", SWITCH_TYPE_STRING, SWITCH_MODE_OVERWRITE,
-                  "read", "specify mode (read, update, overwrite, or erase)");
+                  "read", "specify mode (read, update, overwrite, erase or "
+                  "setro/setrw)");
 
 SWITCH SwitchRo("ro", "general", SWITCH_TYPE_STRING, SWITCH_MODE_ACCUMULATE,
                   "$none$", "specify ape tag to set read only");
@@ -586,6 +604,11 @@ Mode overwrite:
 Mode erase:
     Remove the APE tag from file input-file
 
+Mode setro|setrw:
+    Set the APE tag read only or read write
+        e.g.: setro
+    set the ape tag read only
+
 Switch summary:
 
 )STR";
@@ -617,6 +640,9 @@ void HandleModeRead(TAG *tag) {
   map<string, string> items;
 
   cout << "Found APE tag at offset " + decstr(tag->TagOffset()) + "\n";
+  if ((tag->Flags() & APE_FLAG_READONLY) == APE_FLAG_READONLY) {
+    cout << "TAG IS SET READ ONLY\n";
+  }
   cout << "Items:\n";
   for (ITEM_SET::const_iterator it = tag->Items().begin();
        it != tag->Items().end(); ++it) {
@@ -776,6 +802,22 @@ void HandleModeUpdate(TAG *tag) {
   }
 }
 
+void HandleRoRw(TAG *tag, const BOOL &ro) {
+  if (ro) {
+    Debug("setting tag read only\n");
+
+    UINT32 flags = tag->Flags();
+    flags |= APE_FLAG_READONLY;
+    tag->SetFlags(flags);
+  } else {
+    Debug("setting tag read write\n");
+
+    UINT32 flags = tag->Flags();
+    flags &= ~APE_FLAG_READONLY;
+    tag->SetFlags(flags);
+  }
+}
+
 // ========================================================================
 int main(int argc, char *argv[]) {
   RegisterImageName(argv[0]);
@@ -816,7 +858,8 @@ int main(int argc, char *argv[]) {
   if (filename == "")
     Error("no input file specified\n");
 
-  const BOOL change_file = (mode == "overwrite" || mode == "update");
+  const BOOL change_file = (mode == "overwrite" || mode == "update"
+                            || mode == "setro" || mode == "setrw");
 
   fstream input(filename.c_str(),
                 change_file ? (ios_base::in | ios_base::out) : ios_base::in);
@@ -832,12 +875,20 @@ int main(int argc, char *argv[]) {
       HandleModeRead(tag.get());
     }
   } else if (mode == "update") {
-    HandleModeUpdate(tag.get());
-    WriteApeTag(input, tag.get(), filename);
+    if ((tag->Flags() & APE_FLAG_READONLY) == APE_FLAG_READONLY) {
+      Error("tag is read only\n");
+    } else {
+      HandleModeUpdate(tag.get());
+      WriteApeTag(input, tag.get(), filename);
+    }
   } else if (mode == "overwrite") {
-    tag->DelAllItems();
-    HandleModeUpdate(tag.get());
-    WriteApeTag(input, tag.get(), filename);
+    if ((tag->Flags() & APE_FLAG_READONLY) == APE_FLAG_READONLY) {
+      Error("tag is read only\n");
+    } else {
+      tag->DelAllItems();
+      HandleModeUpdate(tag.get());
+      WriteApeTag(input, tag.get(), filename);
+    }
   } else if (mode == "erase") {
     if (tag->TagOffset() == 0) {
       cout << "No valid APE tag found\n";
@@ -853,6 +904,13 @@ int main(int argc, char *argv[]) {
           Warning("truncating file failed");
         }
       }
+    }
+  } else if (mode == "setro" || mode == "setrw") {
+    if (tag->TagOffset() == 0) {
+      cout << "No valid APE tag found\n";
+    } else {
+      HandleRoRw(tag.get(), (mode == "setro"));
+      WriteApeTag(input, tag.get(), filename);
     }
   } else {
     Error("unknown mode\n");

--- a/main.C
+++ b/main.C
@@ -577,11 +577,16 @@ void HandleModeRead(TAG *tag) {
 
     items[key] = value;
 
-    if (flags == APE_TAG_ITEM_FLAG_BINARY) {
-      cout << "\"" + key + "\"" + " <Binary>\n";
-    } else {
-      cout << "\"" + key + "\" \"" + value + "\"\n";
+    string dumpitem;
+    if ((flags & APE_TAG_ITEM_FLAG_EXTERNAL_RESOURCE) == APE_TAG_ITEM_FLAG_EXTERNAL_RESOURCE) {
+        dumpitem = "ERS \"" + key + "\" \"" + value + "\"";
+    } else if ((flags & APE_TAG_ITEM_FLAG_BINARY) == APE_TAG_ITEM_FLAG_BINARY) {
+        dumpitem = "BIN \"" + key + "\"";
+    } else if ((flags & APE_TAG_ITEM_FLAG_TEXT) == APE_TAG_ITEM_FLAG_TEXT) {
+        dumpitem = "TXT \"" + key + "\" \"" + value + "\"";
     }
+
+    cout << dumpitem + "\n";
   }
 
   const UINT32 num_file_items = SwitchFilePair.ValueNumber();

--- a/main.C
+++ b/main.C
@@ -98,6 +98,11 @@ LOCALFUN string ExtractVersion() {
 #define APE_FLAG_HAVE_HEADER (1 << 31)
 #define APE_FLAG_IS_HEADER (1 << 29)
 
+#define APE_TAG_ITEM_FLAG_TEXT (0 << 0)
+#define APE_TAG_ITEM_FLAG_BINARY (1 << 1)
+#define APE_TAG_ITEM_FLAG_EXTERNAL_RESOURCE (1 << 2)
+#define APE_TAG_ITEM_FLAG_RESERVED (1 << 3)
+
 typedef struct {
   char _magic[8];
   char _version[4];
@@ -547,7 +552,7 @@ void HandleModeRead(TAG *tag) {
 
     items[key] = value;
 
-    if (flags == 2) {
+    if (flags == APE_TAG_ITEM_FLAG_BINARY) {
       cout << "\"" + key + "\"" + " <Binary>\n";
     } else {
       cout << "\"" + key + "\" \"" + value + "\"\n";
@@ -626,7 +631,7 @@ void HandleModeUpdate(TAG *tag) {
 
     Debug("adding (" + key + "," + val + ")\n");
 
-    tag->UpdateItem(new ITEM(key, val, 0));
+    tag->UpdateItem(new ITEM(key, val, APE_TAG_ITEM_FLAG_TEXT));
   }
 
   const UINT32 num_file_items = SwitchFilePair.ValueNumber();
@@ -668,7 +673,7 @@ void HandleModeUpdate(TAG *tag) {
 
     Debug("adding (" + key + "," + " <Binary>)\n");
 
-    tag->UpdateItem(new ITEM(key, val, 2));
+    tag->UpdateItem(new ITEM(key, val, APE_TAG_ITEM_FLAG_BINARY));
   }
 }
 

--- a/test.sh
+++ b/test.sh
@@ -7,6 +7,7 @@ set -o errexit
 readonly APETAG=./apetag
 readonly MP3=./empty.mp3
 readonly MP3_CLONE=./clone.mp3
+readonly MP3_CLONE_TAGDUMP=./clone.apetag
 readonly BIN1=./test.sh
 readonly BIN2=./COPYING
 readonly BIN3=./README.md
@@ -15,6 +16,7 @@ COUNTER=0
 
 cleanup() {
     rm -f ${MP3_CLONE}
+    rm -f ${MP3_CLONE_TAGDUMP}
 }
 trap cleanup EXIT
 
@@ -174,6 +176,14 @@ ${APETAG} -i ${MP3_CLONE} -m update -f "test.sh"=${BIN1} -p Title="--title2--" -
 ${APETAG} -i ${MP3_CLONE} -m setro
 ${APETAG} -i ${MP3_CLONE} -m read
 ${APETAG} -i ${MP3_CLONE} -m setrw
+${APETAG} -i ${MP3_CLONE} -m read
+
+newtest
+${APETAG} -i ${MP3_CLONE} -m update -f "test.sh"=${BIN1} -p Title="--title2--" -r "testpage"="http://bo.gus/website/page.html"
+${APETAG} -i ${MP3_CLONE} -m read -file ${MP3_CLONE_TAGDUMP}
+${APETAG} -i ${MP3_CLONE} -m erase
+${APETAG} -i ${MP3_CLONE} -m read
+${APETAG} -i ${MP3_CLONE} -m overwrite -file ${MP3_CLONE_TAGDUMP}
 ${APETAG} -i ${MP3_CLONE} -m read
 
 

--- a/test.sh
+++ b/test.sh
@@ -13,8 +13,12 @@ readonly BIN3=./README.md
 
 COUNTER=0
 
-clone() {
+cleanup() {
     rm -f ${MP3_CLONE}
+}
+trap cleanup EXIT
+
+clone() {
     cp ${MP3} ${MP3_CLONE}
 }
 

--- a/test.sh
+++ b/test.sh
@@ -33,6 +33,8 @@ ${APETAG} -i ${MP3_CLONE} -m read
 newtest
 ${APETAG} -i ${MP3_CLONE} -m update -p  "Title=--title--"
 ${APETAG} -i ${MP3_CLONE} -m read
+${APETAG} -i ${MP3_CLONE} -m update -p  "title=--title--"
+${APETAG} -i ${MP3_CLONE} -m read
 
 
 newtest
@@ -54,6 +56,8 @@ ${APETAG} -i ${MP3_CLONE} -m read
 newtest
 ${APETAG} -i ${MP3_CLONE} -m update -f  "Test.sh"=${BIN1}
 ${APETAG} -i ${MP3_CLONE} -m read
+${APETAG} -i ${MP3_CLONE} -m update -f  "test.sh"=${BIN1}
+${APETAG} -i ${MP3_CLONE} -m read
 
 
 newtest
@@ -74,6 +78,8 @@ ${APETAG} -i ${MP3_CLONE} -m read
 
 newtest
 ${APETAG} -i ${MP3_CLONE} -m update -f "Test.sh"=${BIN1} -p "Test"="File"
+${APETAG} -i ${MP3_CLONE} -m read
+${APETAG} -i ${MP3_CLONE} -m update -f "test.sh"=${BIN1} -p "test"="File"
 ${APETAG} -i ${MP3_CLONE} -m read
 
 echo "done"

--- a/test.sh
+++ b/test.sh
@@ -39,6 +39,9 @@ ${APETAG} -i ${MP3_CLONE} -m update -p  "Title=--title--"
 ${APETAG} -i ${MP3_CLONE} -m read
 ${APETAG} -i ${MP3_CLONE} -m update -p  "title=--title--"
 ${APETAG} -i ${MP3_CLONE} -m read
+${APETAG} -i ${MP3_CLONE} -m update -ro "titl"
+${APETAG} -i ${MP3_CLONE} -m update -rw "titl"
+${APETAG} -i ${MP3_CLONE} -m read
 
 
 newtest
@@ -47,6 +50,19 @@ ${APETAG} -i ${MP3_CLONE} -m read
 ${APETAG} -i ${MP3_CLONE} -m update -p "Title=--title3--" -p "Year="
 ${APETAG} -i ${MP3_CLONE} -m read
 ${APETAG} -i ${MP3_CLONE} -m erase
+${APETAG} -i ${MP3_CLONE} -m read
+
+
+newtest
+${APETAG} -i ${MP3_CLONE} -m update -p "Title=--title2--" -p "Year=--year2--"
+${APETAG} -i ${MP3_CLONE} -m update -ro "Title"
+${APETAG} -i ${MP3_CLONE} -m update -p "Title=--title3--"
+${APETAG} -i ${MP3_CLONE} -m read
+${APETAG} -i ${MP3_CLONE} -m overwrite
+${APETAG} -i ${MP3_CLONE} -m read
+${APETAG} -i ${MP3_CLONE} -m update -rw "Title"
+${APETAG} -i ${MP3_CLONE} -m read
+${APETAG} -i ${MP3_CLONE} -m overwrite
 ${APETAG} -i ${MP3_CLONE} -m read
 
 
@@ -62,6 +78,9 @@ ${APETAG} -i ${MP3_CLONE} -m update -f  "Test.sh"=${BIN1}
 ${APETAG} -i ${MP3_CLONE} -m read
 ${APETAG} -i ${MP3_CLONE} -m update -f  "test.sh"=${BIN1}
 ${APETAG} -i ${MP3_CLONE} -m read
+${APETAG} -i ${MP3_CLONE} -m update -ro "test"
+${APETAG} -i ${MP3_CLONE} -m update -rw "test"
+${APETAG} -i ${MP3_CLONE} -m read
 
 
 newtest
@@ -70,6 +89,19 @@ ${APETAG} -i ${MP3_CLONE} -m read
 ${APETAG} -i ${MP3_CLONE} -m update -f "Test.sh"=${BIN3} -f "NotTest="
 ${APETAG} -i ${MP3_CLONE} -m read
 ${APETAG} -i ${MP3_CLONE} -m erase
+${APETAG} -i ${MP3_CLONE} -m read
+
+
+newtest
+${APETAG} -i ${MP3_CLONE} -m update -f "Test.sh"=${BIN2} -f "NotTest"=${BIN2}
+${APETAG} -i ${MP3_CLONE} -m update -ro "Test.sh"
+${APETAG} -i ${MP3_CLONE} -m update -f "Test.sh"=${BIN3}
+${APETAG} -i ${MP3_CLONE} -m read
+${APETAG} -i ${MP3_CLONE} -m overwrite
+${APETAG} -i ${MP3_CLONE} -m read
+${APETAG} -i ${MP3_CLONE} -m update -rw "Test.sh"
+${APETAG} -i ${MP3_CLONE} -m read
+${APETAG} -i ${MP3_CLONE} -m overwrite
 ${APETAG} -i ${MP3_CLONE} -m read
 
 
@@ -85,6 +117,9 @@ ${APETAG} -i ${MP3_CLONE} -m update -r  "TestPage=http://bo.gus/addr"
 ${APETAG} -i ${MP3_CLONE} -m read
 ${APETAG} -i ${MP3_CLONE} -m update -r  "testpage=http://bo.gus/addr"
 ${APETAG} -i ${MP3_CLONE} -m read
+${APETAG} -i ${MP3_CLONE} -m update -ro "page"
+${APETAG} -i ${MP3_CLONE} -m update -rw "page"
+${APETAG} -i ${MP3_CLONE} -m read
 
 
 newtest
@@ -93,6 +128,19 @@ ${APETAG} -i ${MP3_CLONE} -m read
 ${APETAG} -i ${MP3_CLONE} -m update -r "TestPage=http://bo.gus/addr/testpage.html" -r "ExternalCover="
 ${APETAG} -i ${MP3_CLONE} -m read
 ${APETAG} -i ${MP3_CLONE} -m erase
+${APETAG} -i ${MP3_CLONE} -m read
+
+
+newtest
+${APETAG} -i ${MP3_CLONE} -m update -r "TestPage=http://bo.gus/website/page.html" -r "ExternalCover=/dev/zero"
+${APETAG} -i ${MP3_CLONE} -m update -ro "TestPage"
+${APETAG} -i ${MP3_CLONE} -m update -r "TestPage=http://bo.gus/addr/testpage.html"
+${APETAG} -i ${MP3_CLONE} -m read
+${APETAG} -i ${MP3_CLONE} -m overwrite
+${APETAG} -i ${MP3_CLONE} -m read
+${APETAG} -i ${MP3_CLONE} -m update -rw "TestPage"
+${APETAG} -i ${MP3_CLONE} -m read
+${APETAG} -i ${MP3_CLONE} -m overwrite
 ${APETAG} -i ${MP3_CLONE} -m read
 
 
@@ -107,6 +155,18 @@ newtest
 ${APETAG} -i ${MP3_CLONE} -m update -f "Test.sh"=${BIN1} -p "Test"="File" -r "ExternalCover"="/dev/zero"
 ${APETAG} -i ${MP3_CLONE} -m read
 ${APETAG} -i ${MP3_CLONE} -m update -f "test.sh"=${BIN1} -p "test"="File" -r "externalcover"="/dev/zero"
+${APETAG} -i ${MP3_CLONE} -m read
+
+
+newtest
+${APETAG} -i ${MP3_CLONE} -m update -f "test.sh"=${BIN1} -p "test"="file" -r "externalcover"="/dev/zero"
+${APETAG} -i ${MP3_CLONE} -m update -ro "test.sh" -ro "test" -ro "externalcover"
+${APETAG} -i ${MP3_CLONE} -m read
+${APETAG} -i ${MP3_CLONE} -m update -f "test.sh"=${BIN2} -p "test"="FILE2" -r "externalcover"="/DEV/ZERO"
+${APETAG} -i ${MP3_CLONE} -m read
+${APETAG} -i ${MP3_CLONE} -m update -rw "test.sh" -rw "test" -rw "externalcover"
+${APETAG} -i ${MP3_CLONE} -m read
+${APETAG} -i ${MP3_CLONE} -m update -f "test.sh"=${BIN2} -p "test"="FILE2" -r "externalcover"="/DEV/ZERO"
 ${APETAG} -i ${MP3_CLONE} -m read
 
 echo "done"

--- a/test.sh
+++ b/test.sh
@@ -81,9 +81,32 @@ ${APETAG} -i ${MP3_CLONE} -m read
 
 
 newtest
-${APETAG} -i ${MP3_CLONE} -m update -f "Test.sh"=${BIN1} -p "Test"="File"
+${APETAG} -i ${MP3_CLONE} -m update -r  "TestPage=http://bo.gus/addr"
 ${APETAG} -i ${MP3_CLONE} -m read
-${APETAG} -i ${MP3_CLONE} -m update -f "test.sh"=${BIN1} -p "test"="File"
+${APETAG} -i ${MP3_CLONE} -m update -r  "testpage=http://bo.gus/addr"
+${APETAG} -i ${MP3_CLONE} -m read
+
+
+newtest
+${APETAG} -i ${MP3_CLONE} -m update -r "TestPage=http://bo.gus/website/page.html" -r "ExternalCover=/dev/zero"
+${APETAG} -i ${MP3_CLONE} -m read
+${APETAG} -i ${MP3_CLONE} -m update -r "TestPage=http://bo.gus/addr/testpage.html" -r "ExternalCover="
+${APETAG} -i ${MP3_CLONE} -m read
+${APETAG} -i ${MP3_CLONE} -m erase
+${APETAG} -i ${MP3_CLONE} -m read
+
+
+newtest
+${APETAG} -i ${MP3_CLONE} -m update -r "TestPage=http://bo.gus/website/page.html" -r "ExternalCover=/dev/zero"
+${APETAG} -i ${MP3_CLONE} -m read
+${APETAG} -i ${MP3_CLONE} -m overwrite -r "TestPage=http://bo.gus/addr/testpage.html"
+${APETAG} -i ${MP3_CLONE} -m read
+
+
+newtest
+${APETAG} -i ${MP3_CLONE} -m update -f "Test.sh"=${BIN1} -p "Test"="File" -r "ExternalCover"="/dev/zero"
+${APETAG} -i ${MP3_CLONE} -m read
+${APETAG} -i ${MP3_CLONE} -m update -f "test.sh"=${BIN1} -p "test"="File" -r "externalcover"="/dev/zero"
 ${APETAG} -i ${MP3_CLONE} -m read
 
 echo "done"

--- a/test.sh
+++ b/test.sh
@@ -169,4 +169,12 @@ ${APETAG} -i ${MP3_CLONE} -m read
 ${APETAG} -i ${MP3_CLONE} -m update -f "test.sh"=${BIN2} -p "test"="FILE2" -r "externalcover"="/DEV/ZERO"
 ${APETAG} -i ${MP3_CLONE} -m read
 
+newtest
+${APETAG} -i ${MP3_CLONE} -m update -f "test.sh"=${BIN1} -p Title="--title2--" -r "testpage"="http://bo.gus/website/page.html"
+${APETAG} -i ${MP3_CLONE} -m setro
+${APETAG} -i ${MP3_CLONE} -m read
+${APETAG} -i ${MP3_CLONE} -m setrw
+${APETAG} -i ${MP3_CLONE} -m read
+
+
 echo "done"


### PR DESCRIPTION
Depends on https://github.com/robertmuth/apetag/pull/10

Allow dumping to and overwriting the ape tag from an external file.