### PR TITLE
Check that keys contain only printable ASCII characters

### DIFF
--- a/golden.out
+++ b/golden.out
@@ -31,6 +31,22 @@ TXT	RW	Title	--title3--
 No valid APE tag found
 ============================================================
 test 4
+Found APE tag at offset 193
+Items:
+Type	RO/RW	Field	Value
+TXT	RW	Year	--yeár2--
+TXT	RW	Title	--tïtlé2--
+W: key "Tïtle" contains a non-printable ASCII character
+W: skipping invalid key "Tïtle"
+W: key "Yeár" contains a non-printable ASCII character
+W: skipping invalid key "Yeár"
+Found APE tag at offset 193
+Items:
+Type	RO/RW	Field	Value
+TXT	RW	Year	--yeár2--
+TXT	RW	Title	--tïtlé2--
+============================================================
+test 5
 W: read only item with key Title was not modified
 Found APE tag at offset 193
 Items:
@@ -50,7 +66,7 @@ Found APE tag at offset 193
 Items:
 Type	RO/RW	Field	Value
 ============================================================
-test 5
+test 6
 Found APE tag at offset 193
 Items:
 Type	RO/RW	Field	Value
@@ -61,7 +77,7 @@ Items:
 Type	RO/RW	Field	Value
 TXT	RW	Title	--title3--
 ============================================================
-test 6
+test 7
 Found APE tag at offset 193
 Items:
 Type	RO/RW	Field	Value
@@ -77,7 +93,7 @@ Items:
 Type	RO/RW	Field	Value
 BIN	RW	test.sh
 ============================================================
-test 7
+test 8
 Found APE tag at offset 193
 Items:
 Type	RO/RW	Field	Value
@@ -89,7 +105,7 @@ Type	RO/RW	Field	Value
 BIN	RW	Test.sh
 No valid APE tag found
 ============================================================
-test 8
+test 9
 W: read only item with key Test.sh was not modified
 Found APE tag at offset 193
 Items:
@@ -109,7 +125,7 @@ Found APE tag at offset 193
 Items:
 Type	RO/RW	Field	Value
 ============================================================
-test 9
+test 10
 Found APE tag at offset 193
 Items:
 Type	RO/RW	Field	Value
@@ -120,7 +136,7 @@ Items:
 Type	RO/RW	Field	Value
 BIN	RW	Test.sh
 ============================================================
-test 10
+test 11
 Found APE tag at offset 193
 Items:
 Type	RO/RW	Field	Value
@@ -136,7 +152,7 @@ Items:
 Type	RO/RW	Field	Value
 RSC	RW	testpage	http://bo.gus/addr
 ============================================================
-test 11
+test 12
 Found APE tag at offset 193
 Items:
 Type	RO/RW	Field	Value
@@ -148,7 +164,7 @@ Type	RO/RW	Field	Value
 RSC	RW	TestPage	http://bo.gus/addr/testpage.html
 No valid APE tag found
 ============================================================
-test 12
+test 13
 W: read only item with key TestPage was not modified
 Found APE tag at offset 193
 Items:
@@ -173,7 +189,7 @@ Found APE tag at offset 193
 Items:
 Type	RO/RW	Field	Value
 ============================================================
-test 13
+test 14
 Found APE tag at offset 193
 Items:
 Type	RO/RW	Field	Value
@@ -184,7 +200,7 @@ Items:
 Type	RO/RW	Field	Value
 RSC	RW	TestPage	http://bo.gus/addr/testpage.html
 ============================================================
-test 14
+test 15
 Found APE tag at offset 193
 Items:
 Type	RO/RW	Field	Value
@@ -198,7 +214,7 @@ TXT	RW	test	File
 RSC	RW	externalcover	/dev/zero
 BIN	RW	test.sh
 ============================================================
-test 15
+test 16
 Found APE tag at offset 193
 Items:
 Type	RO/RW	Field	Value
@@ -227,7 +243,7 @@ TXT	RW	test	FILE2
 RSC	RW	externalcover	/DEV/ZERO
 BIN	RW	test.sh
 ============================================================
-test 16
+test 17
 Found APE tag at offset 193
 TAG IS SET READ ONLY
 Items:
@@ -242,7 +258,7 @@ TXT	RW	Title	--title2--
 RSC	RW	testpage	http://bo.gus/website/page.html
 BIN	RW	test.sh
 ============================================================
-test 17
+test 18
 Found APE tag at offset 193
 Items:
 Type	RO/RW	Field	Value
@@ -253,8 +269,9 @@ Found APE tag at offset 193
 Items:
 Type	RO/RW	Field	Value
 ============================================================
-test 18
-W: key "ID3" is not allowed
+test 19
+W: key "ID3" is not an allowed key
+W: skipping invalid key "ID3"
 Found APE tag at offset 193
 Items:
 Type	RO/RW	Field	Value

--- a/main.C
+++ b/main.C
@@ -693,6 +693,16 @@ BOOL ValidKey (const string &key) {
       return false;
     }
 
+    // The APEv2 specification requires that keys consist only of ASCII
+    // printable characters
+    for (string::const_iterator it = key.cbegin(); it != key.cend(); ++it) {
+        if (((UINT32)*it < 32) || ((UINT32)*it > 126)) {
+            Warning("key \"" + key +
+                    "\" contains a non-printable ASCII character\n");
+            return false;
+        }
+    }
+
     return true;
 }
 

--- a/main.C
+++ b/main.C
@@ -236,13 +236,6 @@ public:
     const string &newvalue = newitem->Value();
     const UINT32 &newflags = newitem->Flags();
 
-    // The APEv2 specification does not allow the following for keys
-    if (newkey == "ID3" || newkey == "TAG" || newkey == "OggS" ||
-        newkey == "MP+") {
-      Warning("key \"" + newkey + "\" is not allowed\n");
-      return;
-    }
-
     const ITEM *item = FindItem(newkey);
 
     if (item->Key().size()) {
@@ -692,6 +685,17 @@ const pair<string, string> ParsedPair (const string &pair) {
   return make_pair(key, val);
 }
 
+BOOL ValidKey (const string &key) {
+    // The APEv2 specification does not allow the following for keys
+    if (key == "ID3" || key == "TAG" || key == "OggS" ||
+        key == "MP+") {
+      Warning("key \"" + key + "\" is not an allowed key\n");
+      return false;
+    }
+
+    return true;
+}
+
 void HandleModeRead(TAG *tag) {
   map<string, string> items;
 
@@ -793,6 +797,11 @@ void HandleModeUpdate(TAG *tag) {
     const string &key = pair.first;
     const string &val = pair.second;
 
+    if (!ValidKey(key)) {
+        Warning("skipping invalid key \"" + key + "\"\n");
+        continue;
+    }
+
     Debug("adding (" + key + "," + val + ")\n");
 
     tag->UpdateItem(new ITEM(key, val, APE_TAG_ITEM_FLAG_TEXT));
@@ -808,6 +817,11 @@ void HandleModeUpdate(TAG *tag) {
     const string &key = pair.first;
     const string &val = pair.second;
 
+    if (!ValidKey(key)) {
+        Warning("skipping invalid key \"" + key + "\"\n");
+        continue;
+    }
+
     Debug("adding (" + key + "," + val + ")\n");
 
     tag->UpdateItem(new ITEM(key, val, APE_TAG_ITEM_FLAG_EXTERNAL_RESOURCE));
@@ -821,6 +835,11 @@ void HandleModeUpdate(TAG *tag) {
 
     const string &key = pair.first;
     string val = pair.second;
+
+    if (!ValidKey(key)) {
+        Warning("skipping invalid key \"" + key + "\"\n");
+        continue;
+    }
 
     if (val.length()) {
       ifstream file(val.c_str());

--- a/main.C
+++ b/main.C
@@ -665,7 +665,7 @@ Switch summary:
   return -1;
 }
 
-const pair<string, string> ParsedPair (const string &pair) {
+const pair<string, string> ParsedPair(const string &pair) {
   const UINT32 len = pair.length();
 
   UINT32 pos_equal_sign;
@@ -685,7 +685,7 @@ const pair<string, string> ParsedPair (const string &pair) {
   return make_pair(key, val);
 }
 
-BOOL ValidKey (const string &key) {
+BOOL ValidKey(const string &key) {
     // The APEv2 specification does not allow the following for keys
     if (key == "ID3" || key == "TAG" || key == "OggS" ||
         key == "MP+") {
@@ -905,7 +905,7 @@ void HandleRoRw(TAG *tag, const BOOL &ro) {
   }
 }
 
-void HandleTagImport (fstream &input, TAG *tag) {
+void HandleTagImport(fstream &input, TAG *tag) {
   const string &infile = SwitchFile.ValueString();
   fstream in(infile.c_str(), ios_base::in);
 

--- a/test.sh
+++ b/test.sh
@@ -54,6 +54,13 @@ ${APETAG} -i ${MP3_CLONE} -m read
 
 
 newtest
+${APETAG} -i ${MP3_CLONE} -m update -p "Title=--tïtlé2--" -p "Year=--yeár2--"
+${APETAG} -i ${MP3_CLONE} -m read
+${APETAG} -i ${MP3_CLONE} -m update -p "Tïtle=--tïtlé2--" -p "Yeár=--yeár2--"
+${APETAG} -i ${MP3_CLONE} -m read
+
+
+newtest
 ${APETAG} -i ${MP3_CLONE} -m update -p "Title=--title2--" -p "Year=--year2--"
 ${APETAG} -i ${MP3_CLONE} -m update -ro "Title"
 ${APETAG} -i ${MP3_CLONE} -m update -p "Title=--title3--"


### PR DESCRIPTION
This is required by the APEv2 specification.